### PR TITLE
fix: the firmware update routine copies spm_pagesize... in...

### DIFF
--- a/rpi/firmware/update_firmware.c
+++ b/rpi/firmware/update_firmware.c
@@ -119,7 +119,7 @@ static int bl_write_page(const uint8_t *data)
     int     elapsed_us = 0;
 
     buf[0] = CMD_WRITE_PAGE;
-    memcpy(buf + 1, data, SPM_PAGESIZE);
+    memcpy(buf + 1, data, sizeof(buf) - 1);
     if (i2c_write(BL_ADDR, buf, sizeof(buf)) < 0)
         return -1;
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `rpi/firmware/update_firmware.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `rpi/firmware/update_firmware.c:122` |

**Description**: The firmware update routine copies SPM_PAGESIZE bytes starting at buf+1. If buf is allocated as exactly SPM_PAGESIZE bytes (a common off-by-one mistake), this writes one byte past the end of the buffer, corrupting adjacent heap metadata. An attacker who can supply a crafted firmware binary — via a compromised update server, man-in-the-middle attack on the download channel, or physical USB/SD card access — can trigger this overflow to achieve arbitrary code execution in the firmware update process.

## Changes
- `rpi/firmware/update_firmware.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
